### PR TITLE
fix parsing issue with types that contain multiple fields

### DIFF
--- a/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
@@ -437,7 +437,7 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
         [TestMethod]
         public void Create_FlowType_ReturnsFlowType()
         {
-            var expectedData = @"{""staticType"":""A.ca4ee530dafff8ad.Evolution.NFT""}";
+            var expectedData = "A.ca4ee530dafff8ad.Evolution.NFT";
 
             var result = FlowValueType.Create("Type", expectedData);
 
@@ -450,9 +450,12 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
         [TestMethod]
         public void Create_PathType_ReturnsPathType()
         {
-            var valueJson = @"{""domain"": ""storage"",""identifier"": ""flowTokenVault""}";
-
-            var result = FlowValueType.Create("Path", valueJson);
+            Dictionary<string, string> values = new Dictionary<string, string>()
+            {
+                {"domain", "storage"},
+                {"identifier", "flowTokenVault"}
+            };
+            var result = FlowValueType.Create("Path", values);
 
             Assert.IsInstanceOfType(result, typeof(PathType));
 
@@ -465,9 +468,14 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
         [TestMethod]
         public void Create_CapabilityType_ReturnsCapabilityType()
         {
-            var valueJson = @"{""path"": ""/public/someInteger"",""address"": ""0x1"",""borrowType"": ""Int""}";
+            Dictionary<string, string> values = new Dictionary<string, string>()
+            {
+                {"path", "/public/someInteger"},
+                {"address", "0x1"},
+                {"borrowType", "Int"}
+            };
 
-            var result = FlowValueType.Create("Capability", valueJson);
+            var result = FlowValueType.Create("Capability", values);
 
             Assert.IsInstanceOfType(result, typeof(CapabilityType));
 
@@ -513,20 +521,6 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             bool res = FlowValueType.IsPrimitiveType(type);
 
             Assert.AreEqual(expectedValue, res);
-        }
-
-        [TestMethod]
-        public void Create_Type_ReturnsFlowType()
-        {
-            var json = @"{""type"":""Type"",""value"":{""staticType"":""A.ca4ee530dafff8ad.Evolution.NFT""}}";
-
-            var res = FlowValueType.Create("Type", json);
-
-            Assert.IsInstanceOfType(res, typeof(FlowType));
-
-            var flowtype = res as FlowType;
-
-            Assert.AreEqual("A.ca4ee530dafff8ad.Evolution.NFT", flowtype.Data);
         }
     }
 }

--- a/Graffle.FlowSdk/Graffle.FlowSdk.csproj
+++ b/Graffle.FlowSdk/Graffle.FlowSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.7-prerelease</Version>
+    <Version>0.1.8-prerelease</Version>
     <PackageDescription>Sdk for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>

--- a/Graffle.FlowSdk/Types/CapabilityType.cs
+++ b/Graffle.FlowSdk/Types/CapabilityType.cs
@@ -10,7 +10,6 @@ namespace Graffle.FlowSdk.Types
         private const string ADDRESS_NAME = "address";
         private const string BORROW_NAME = "borrowType";
 
-
         public CapabilityType(Dictionary<string, string> values)
             : this(values[PATH_NAME], values[ADDRESS_NAME], values[BORROW_NAME])
         { }

--- a/Graffle.FlowSdk/Types/CapabilityType.cs
+++ b/Graffle.FlowSdk/Types/CapabilityType.cs
@@ -10,6 +10,11 @@ namespace Graffle.FlowSdk.Types
         private const string ADDRESS_NAME = "address";
         private const string BORROW_NAME = "borrowType";
 
+
+        public CapabilityType(Dictionary<string, string> values)
+            : this(values[PATH_NAME], values[ADDRESS_NAME], values[BORROW_NAME])
+        { }
+
         public CapabilityType(string path, string address, string borrowType)
         {
             Data = new Dictionary<string, string>();

--- a/Graffle.FlowSdk/Types/FlowValueType.cs
+++ b/Graffle.FlowSdk/Types/FlowValueType.cs
@@ -80,6 +80,8 @@ namespace Graffle.FlowSdk.Types
                 { Constants.WORD16_TYPE_NAME, (arg) => new Word16Type(arg) },
                 { Constants.WORD32_TYPE_NAME, (arg) => new Word32Type(arg) },
                 { Constants.WORD64_TYPE_NAME, (arg) => new Word64Type(arg) },
+                { Constants.PATH_TYPE_NAME, (arg) => new PathType(arg) },
+                { Constants.CAPABILITY_TYPE_NAME, (arg) => new CapabilityType(arg) }
             };
 
             primitiveTypes = new HashSet<string>()
@@ -154,15 +156,6 @@ namespace Graffle.FlowSdk.Types
             if (typeToResolve == Constants.OPTIONAL_TYPE_NAME)
             {
                 return new OptionalType(Create(splitValues.Last(), value));
-            }
-            else if (typeToResolve == Constants.PATH_TYPE_NAME
-                    || typeToResolve == Constants.CAPABILITY_TYPE_NAME
-                    || typeToResolve == Constants.FLOW_TYPE_NAME)
-            {
-                //the value node for these types is json with additional child elements
-                //use the typed class to parse it
-                var func = typeNameToJson[typeToResolve];
-                return func(value);
             }
 
             if (typeNameToCtor.TryGetValue(typeToResolve, out var ctor))

--- a/Graffle.FlowSdk/Types/PathType.cs
+++ b/Graffle.FlowSdk/Types/PathType.cs
@@ -9,6 +9,10 @@ namespace Graffle.FlowSdk.Types
         private const string DOMAIN_NAME = "domain";
         private const string IDENTIFIER_NAME = "identifier";
 
+        public PathType(Dictionary<string, string> values)
+         : this(values[DOMAIN_NAME], values[IDENTIFIER_NAME])
+        { }
+
         public PathType(string domain, string identifier)
         {
             Data = new Dictionary<string, string>();


### PR DESCRIPTION
I was under the impression that ` FlowValueType Create` would sometimes receive JSON for the `value` parameter - this is incorrect

Basically `value` is instead just the `.Data` value from the FlowValueType