### PR TITLE
Bugfix/dictionary fix

### DIFF
--- a/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
 using Graffle.FlowSdk.Types;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Graffle.FlowSdk.Tests.ValueTypes
@@ -521,6 +522,36 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             bool res = FlowValueType.IsPrimitiveType(type);
 
             Assert.AreEqual(expectedValue, res);
+        }
+
+        [TestMethod]
+        public void DictionaryWithNestedStructs_CreateFromCadence_ReturnsDictionaryType()
+        {
+            var json = "{\"type\":\"Dictionary\",\"value\":[{\"key\":{\"type\":\"String\",\"value\":\"itemVideo\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"https://leela.mypinata.cloud/ipfs/QmeirDvh3TrDgtDdfvyjQXF87DusXksymtzmA4RABBVreo/LOOP.mp4\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":true}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"secondaryColor\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"545454\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":false}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"primaryColor\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"FF803E\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":false}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"itemImage4\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":true}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"itemImage3\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":true}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"itemImage2\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":true}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"season\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"1\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":false}}]}}},{\"key\":{\"type\":\"String\",\"value\":\"itemImage\"},\"value\":{\"type\":\"Struct\",\"value\":{\"id\":\"A.2a37a78609bba037.TheFabricantS1ItemNFT.Metadata\",\"fields\":[{\"name\":\"metadataValue\",\"value\":{\"type\":\"String\",\"value\":\"https://leela.mypinata.cloud/ipfs/QmeirDvh3TrDgtDdfvyjQXF87DusXksymtzmA4RABBVreo/LOOP_poster.png\"}},{\"name\":\"mutable\",\"value\":{\"type\":\"Bool\",\"value\":true}}]}}}]}";
+
+            var result = FlowValueType.CreateFromCadence("Dictionary", json);
+            Assert.IsNotNull(result);
+
+            var dict = result as DictionaryType;
+            var data = dict.Data;
+
+            foreach (var kvp in data)
+            {
+                var key = kvp.Key;
+                var value = kvp.Value;
+
+                Assert.AreEqual("String", key.Type);
+                Assert.AreEqual("Struct", value.Type);
+
+                Assert.IsInstanceOfType(value, typeof(StructType));
+
+                var structType = value as StructType;
+                var structData = structType.Data;
+
+                //just verify the struct has fields
+                //we can rely on tests for StructType for actual field parsing
+                Assert.IsTrue(structData.Any());
+            }
         }
     }
 }

--- a/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
@@ -550,8 +550,102 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
 
                 //just verify the struct has fields
                 //we can rely on tests for StructType for actual field parsing
-                Assert.IsTrue(structData.Any());
+                Assert.IsNotNull(structData);
+                Assert.IsTrue(structData.fields.Any());
+                Assert.IsFalse(string.IsNullOrEmpty(structData.id));
             }
+        }
+
+        [TestMethod]
+        public void Create_StructType_ReturnsStructType()
+        {
+            var id = "structId";
+
+            var intType = new Int16Type(123);
+            var stringType = new StringType("asdf");
+
+            var fields = new List<(string name, FlowValueType value)>()
+            {
+                ("intTypeId", intType),
+                ("stringTypeId", stringType)
+            };
+
+            var value = (id, fields);
+
+            var result = FlowValueType.Create("Struct", value);
+
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(StructType));
+
+            var structType = result as StructType;
+
+            Assert.AreEqual(id, structType.Id);
+
+            var resultFields = structType.Fields;
+            Assert.IsNotNull(resultFields);
+            Assert.AreEqual(fields.Count, resultFields.Count);
+
+            //verify individual fields
+            var firstField = resultFields[0];
+            Assert.AreEqual("intTypeId", firstField.name);
+            var firstValue = firstField.value;
+            Assert.IsNotNull(firstValue);
+            Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
+            var resultIntType = firstValue as Int16Type;
+            Assert.AreEqual(intType.Data, resultIntType.Data);
+
+            var secondField = resultFields[1];
+            Assert.AreEqual("stringTypeId", secondField.name);
+            var secondValue = secondField.value;
+            Assert.IsNotNull(secondValue);
+            Assert.IsInstanceOfType(secondValue, typeof(StringType));
+            var resultStringType = secondValue as StringType;
+            Assert.AreEqual(intType.Data, resultIntType.Data);
+        }
+
+        [TestMethod]
+        public void CreateFromCadence_StructType_ReturnsStructType()
+        {
+            var json = @"{""type"":""Struct"",""value"":{""fields"":[{""name"":""intField"",""value"":{""type"":""Int16"",""value"":""123""}},{""name"":""stringField"",""value"":{""type"":""String"",""value"":""hello""}}],""id"":""idString""}}";
+
+            var result = FlowValueType.CreateFromCadence(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(StructType));
+
+            var structType = result as StructType;
+            Assert.AreEqual("Struct", structType.Type);
+
+            var data = structType.Data;
+            Assert.IsNotNull(data);
+
+            var id = data.id;
+            Assert.AreEqual("idString", id);
+
+            var fields = data.fields;
+            Assert.IsNotNull(fields);
+            Assert.AreEqual(2, fields.Count);
+
+            //verify data
+            var firstName = fields[0].name;
+            Assert.AreEqual("intField", firstName);
+
+            var firstValue = fields[0].value;
+            Assert.IsNotNull(firstValue);
+            Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
+
+            var intType = firstValue as Int16Type;
+            Assert.AreEqual(123, intType.Data);
+
+            var secondName = fields[1].name;
+            Assert.AreEqual("stringField", secondName);
+
+            var secondValue = fields[1].value;
+            Assert.IsNotNull(secondValue);
+            Assert.IsInstanceOfType(secondValue, typeof(StringType));
+
+            var stringType = secondValue as StringType;
+            Assert.AreEqual("hello", stringType.Data);
         }
     }
 }

--- a/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Graffle.FlowSdk.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Graffle.FlowSdk.Tests.ValueTypes
+{
+    [TestClass]
+    public class StructTypeTests
+    {
+        [TestMethod]
+        public void AsJsonCadenceDataFormat_ReturnsValidJson()
+        {
+            var expectedJson = @"{""type"":""Struct"",""value"":{""fields"":[{""name"":""intField"",""value"":{""type"":""Int16"",""value"":""123""}},{""name"":""stringField"",""value"":{""type"":""String"",""value"":""hello""}}],""id"":""idString""}}";
+
+            var id = "idString";
+            var intType = new Int16Type(123);
+            var stringType = new StringType("hello");
+            var fields = new List<(string, FlowValueType)>()
+            {
+                ("intField", intType),
+                ("stringField", stringType)
+            };
+
+            var structType = new StructType(id, fields);
+
+            var json = structType.AsJsonCadenceDataFormat();
+
+            Assert.AreEqual(expectedJson, json);
+            Assert.AreEqual(id, structType.Id);
+        }
+
+        [TestMethod]
+        public void DataAsJson_ReturnsValidJson()
+        {
+            var expectedJson = @"{""fields"":[{""name"":""intField"",""value"":{""type"":""Int16"",""value"":""123""}},{""name"":""stringField"",""value"":{""type"":""String"",""value"":""hello""}}],""id"":""idString""}";
+
+            var id = "idString";
+            var intType = new Int16Type(123);
+            var stringType = new StringType("hello");
+            var fields = new List<(string, FlowValueType)>()
+            {
+                ("intField", intType),
+                ("stringField", stringType)
+            };
+
+            var structType = new StructType(id, fields);
+
+            var json = structType.DataAsJson();
+
+            Assert.AreEqual(expectedJson, json);
+            Assert.AreEqual(id, structType.Id);
+        }
+
+        [TestMethod]
+        public void GivenValidJson_FromJson_ReturnsStructType()
+        {
+            var json = @"{""type"":""Struct"",""value"":{""fields"":[{""name"":""intField"",""value"":{""type"":""Int16"",""value"":""123""}},{""name"":""stringField"",""value"":{""type"":""String"",""value"":""hello""}}],""id"":""idString""}}";
+
+            var structType = StructType.FromJson(json);
+            Assert.IsNotNull(structType);
+
+            Assert.AreEqual("Struct", structType.Type);
+
+            var data = structType.Data;
+            Assert.IsNotNull(data);
+            Assert.AreEqual(2, data.Count);
+
+            //verify data
+            var firstName = data[0].name;
+            Assert.AreEqual("intField", firstName);
+
+            var firstValue = data[0].value;
+            Assert.IsNotNull(firstValue);
+            Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
+
+            var intType = firstValue as Int16Type;
+            Assert.AreEqual(123, intType.Data);
+
+            var secondName = data[1].name;
+            Assert.AreEqual("stringField", secondName);
+
+            var secondValue = data[1].value;
+            Assert.IsNotNull(secondValue);
+            Assert.IsInstanceOfType(secondValue, typeof(StringType));
+
+            var stringType = secondValue as StringType;
+            Assert.AreEqual("hello", stringType.Data);
+        }
+    }
+}

--- a/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
@@ -65,23 +65,29 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
 
             var data = structType.Data;
             Assert.IsNotNull(data);
-            Assert.AreEqual(2, data.Count);
+
+            var id = data.id;
+            Assert.AreEqual("idString", id);
+
+            var fields = data.fields;
+            Assert.IsNotNull(fields);
+            Assert.AreEqual(2, fields.Count);
 
             //verify data
-            var firstName = data[0].name;
+            var firstName = fields[0].name;
             Assert.AreEqual("intField", firstName);
 
-            var firstValue = data[0].value;
+            var firstValue = fields[0].value;
             Assert.IsNotNull(firstValue);
             Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
 
             var intType = firstValue as Int16Type;
             Assert.AreEqual(123, intType.Data);
 
-            var secondName = data[1].name;
+            var secondName = fields[1].name;
             Assert.AreEqual("stringField", secondName);
 
-            var secondValue = data[1].value;
+            var secondValue = fields[1].value;
             Assert.IsNotNull(secondValue);
             Assert.IsInstanceOfType(secondValue, typeof(StringType));
 

--- a/Graffle.FlowSdk/Graffle.FlowSdk.csproj
+++ b/Graffle.FlowSdk/Graffle.FlowSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.8-prerelease</Version>
+    <Version>0.1.9-prerelease</Version>
     <PackageDescription>Sdk for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>

--- a/Graffle.FlowSdk/Types/Constants.cs
+++ b/Graffle.FlowSdk/Types/Constants.cs
@@ -31,5 +31,6 @@ namespace Graffle.FlowSdk.Types
         public const string WORD16_TYPE_NAME = "Word16";
         public const string WORD32_TYPE_NAME = "Word32";
         public const string WORD64_TYPE_NAME = "Word64";
+        public const string STRUCT_TYPE_NAME = "Struct";
     }
 }

--- a/Graffle.FlowSdk/Types/FlowValueType.cs
+++ b/Graffle.FlowSdk/Types/FlowValueType.cs
@@ -50,6 +50,7 @@ namespace Graffle.FlowSdk.Types
                 { Constants.WORD64_TYPE_NAME, Word64Type.FromJson },
                 { Constants.PATH_TYPE_NAME, PathType.FromJson },
                 { Constants.CAPABILITY_TYPE_NAME, CapabilityType.FromJson },
+                { Constants.STRUCT_TYPE_NAME, StructType.FromJson }
             };
 
             typeNameToCtor = new Dictionary<string, FlowValueTypeConstructor>()

--- a/Graffle.FlowSdk/Types/FlowValueType.cs
+++ b/Graffle.FlowSdk/Types/FlowValueType.cs
@@ -82,7 +82,8 @@ namespace Graffle.FlowSdk.Types
                 { Constants.WORD32_TYPE_NAME, (arg) => new Word32Type(arg) },
                 { Constants.WORD64_TYPE_NAME, (arg) => new Word64Type(arg) },
                 { Constants.PATH_TYPE_NAME, (arg) => new PathType(arg) },
-                { Constants.CAPABILITY_TYPE_NAME, (arg) => new CapabilityType(arg) }
+                { Constants.CAPABILITY_TYPE_NAME, (arg) => new CapabilityType(arg) },
+                { Constants.STRUCT_TYPE_NAME, (arg) => new StructType(arg) }
             };
 
             primitiveTypes = new HashSet<string>()

--- a/Graffle.FlowSdk/Types/StructType.cs
+++ b/Graffle.FlowSdk/Types/StructType.cs
@@ -7,12 +7,9 @@ namespace Graffle.FlowSdk.Types
 {
     public class StructType : FlowValueType
     {
-        protected StructType() { }
-
         public StructType(string id, List<(string name, FlowValueType value)> fields)
-        {
-            Data = (id, fields);
-        }
+            : this((id, fields))
+        { }
 
         public StructType((string id, List<(string name, FlowValueType value)> fields) value)
         {

--- a/Graffle.FlowSdk/Types/StructType.cs
+++ b/Graffle.FlowSdk/Types/StructType.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Graffle.FlowSdk.Types
+{
+    public class StructType : FlowValueType
+    {
+        public StructType() { }
+
+        public StructType(string id, IList<(string name, FlowValueType value)> fields)
+        {
+            Data = fields;
+            Id = id;
+        }
+
+        public string Id { get; set; }
+
+        public IList<(string name, FlowValueType value)> Data { get; set; }
+
+        [JsonPropertyName("type")]
+        public override string Type => Constants.STRUCT_TYPE_NAME;
+
+        public override string AsJsonCadenceDataFormat()
+        {
+            var valueArray = ValuesAsJson();
+            var arrayString = $"[{string.Join(",", valueArray)}]";
+            var result = $"{{\"type\":\"{Type}\",\"value\":{{\"fields\":{arrayString},\"id\":\"{Id}\"}}}}";
+            return result;
+        }
+
+        public override string DataAsJson()
+        {
+            var valueArray = ValuesAsJson();
+            var arrayString = $"[{string.Join(",", valueArray)}]";
+            var result = $"{{\"fields\":{arrayString},\"id\":\"{Id}\"}}";
+            return result;
+        }
+
+        public static StructType FromJson(string json)
+        {
+            var parsedJson = JsonDocument.Parse(json);
+            var root = parsedJson.RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
+            var rootValue = root.FirstOrDefault(z => z.Key == "value").Value;
+
+            var id = rootValue.GetProperty("id").GetString(); //struct id
+            var fields = rootValue.GetProperty("fields").EnumerateArray().Select(h => h.EnumerateObject().ToDictionary(n => n.Name, n => n.Value.ToString())); //field array
+
+            var parsedFields = new List<(string, FlowValueType)>();
+            foreach (var item in fields)
+            {
+                //name
+                var name = item.Values.First();
+
+                //value
+                var valueJson = JsonDocument.Parse(item.Values.Last());
+                var valueJsonElementsKvp = valueJson.RootElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
+                var valueJsonType = valueJsonElementsKvp.FirstOrDefault(z => z.Key == "type").Value;
+                var flowValue = FlowValueType.CreateFromCadence(valueJsonType.GetString(), item.Values.Last());
+
+                parsedFields.Add((name, flowValue));
+            }
+
+            var result = new StructType(id, parsedFields);
+            return result;
+        }
+
+        private IEnumerable<string> ValuesAsJson()
+        {
+            foreach (var item in Data)
+            {
+                var name = item.name;
+                var value = item.value.AsJsonCadenceDataFormat();
+                var entry = $"{{\"name\":\"{name}\",\"value\":{value}}}";
+                yield return entry;
+            }
+        }
+    }
+}

--- a/Graffle.FlowSdk/Types/StructType.cs
+++ b/Graffle.FlowSdk/Types/StructType.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -10,7 +7,7 @@ namespace Graffle.FlowSdk.Types
 {
     public class StructType : FlowValueType
     {
-        public StructType() { }
+        protected StructType() { }
 
         public StructType(string id, IList<(string name, FlowValueType value)> fields)
         {

--- a/Graffle.FlowSdk/Types/StructType.cs
+++ b/Graffle.FlowSdk/Types/StructType.cs
@@ -9,22 +9,28 @@ namespace Graffle.FlowSdk.Types
     {
         protected StructType() { }
 
-        public StructType(string id, IList<(string name, FlowValueType value)> fields)
+        public StructType(string id, List<(string name, FlowValueType value)> fields)
         {
-            Data = fields;
-            Id = id;
+            Data = (id, fields);
         }
 
-        public string Id { get; set; }
+        public StructType((string id, List<(string name, FlowValueType value)> fields) value)
+        {
+            Data = value;
+        }
 
-        public IList<(string name, FlowValueType value)> Data { get; set; }
+        public string Id => Data.id;
+
+        public List<(string name, FlowValueType value)> Fields => Data.fields;
+
+        public (string id, List<(string name, FlowValueType value)> fields) Data { get; set; }
 
         [JsonPropertyName("type")]
         public override string Type => Constants.STRUCT_TYPE_NAME;
 
         public override string AsJsonCadenceDataFormat()
         {
-            var valueArray = ValuesAsJson();
+            var valueArray = FieldsAsJson();
             var arrayString = $"[{string.Join(",", valueArray)}]";
             var result = $"{{\"type\":\"{Type}\",\"value\":{{\"fields\":{arrayString},\"id\":\"{Id}\"}}}}";
             return result;
@@ -32,7 +38,7 @@ namespace Graffle.FlowSdk.Types
 
         public override string DataAsJson()
         {
-            var valueArray = ValuesAsJson();
+            var valueArray = FieldsAsJson();
             var arrayString = $"[{string.Join(",", valueArray)}]";
             var result = $"{{\"fields\":{arrayString},\"id\":\"{Id}\"}}";
             return result;
@@ -66,9 +72,9 @@ namespace Graffle.FlowSdk.Types
             return result;
         }
 
-        private IEnumerable<string> ValuesAsJson()
+        private IEnumerable<string> FieldsAsJson()
         {
-            foreach (var item in Data)
+            foreach (var item in Data.fields)
             {
                 var name = item.name;
                 var value = item.value.AsJsonCadenceDataFormat();


### PR DESCRIPTION
graffle sdk has an issue with the following testnet transaction: https://testnet.flowscan.org/transaction/2d724581f3758d9515951c585ee7795e5e22755f81d4268688a601c87ec8fbd7

Specifically see data for contract `A.2a37a78609bba037.TheFabricantS1ItemNFT` - this contract a Dictionary full of structs which is currently not supported by the code here for `DictionaryType`.

Solution: add code to deserialize cadence json for structs