### PR TITLE
Feature/struct data

### DIFF
--- a/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/FlowValueTypeTests.cs
@@ -551,8 +551,8 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
                 //just verify the struct has fields
                 //we can rely on tests for StructType for actual field parsing
                 Assert.IsNotNull(structData);
-                Assert.IsTrue(structData.fields.Any());
-                Assert.IsFalse(string.IsNullOrEmpty(structData.id));
+                Assert.IsTrue(structData.Fields.Any());
+                Assert.IsFalse(string.IsNullOrEmpty(structData.Id));
             }
         }
 
@@ -564,13 +564,13 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             var intType = new Int16Type(123);
             var stringType = new StringType("asdf");
 
-            var fields = new List<(string name, FlowValueType value)>()
+            var fields = new List<StructField>()
             {
-                ("intTypeId", intType),
-                ("stringTypeId", stringType)
+                new StructField("intTypeId", intType),
+                new StructField("stringTypeId", stringType)
             };
 
-            var value = (id, fields);
+            var value = new StructData(id, fields);
 
             var result = FlowValueType.Create("Struct", value);
 
@@ -587,16 +587,16 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
 
             //verify individual fields
             var firstField = resultFields[0];
-            Assert.AreEqual("intTypeId", firstField.name);
-            var firstValue = firstField.value;
+            Assert.AreEqual("intTypeId", firstField.Name);
+            var firstValue = firstField.Value;
             Assert.IsNotNull(firstValue);
             Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
             var resultIntType = firstValue as Int16Type;
             Assert.AreEqual(intType.Data, resultIntType.Data);
 
             var secondField = resultFields[1];
-            Assert.AreEqual("stringTypeId", secondField.name);
-            var secondValue = secondField.value;
+            Assert.AreEqual("stringTypeId", secondField.Name);
+            var secondValue = secondField.Value;
             Assert.IsNotNull(secondValue);
             Assert.IsInstanceOfType(secondValue, typeof(StringType));
             var resultStringType = secondValue as StringType;
@@ -619,28 +619,28 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             var data = structType.Data;
             Assert.IsNotNull(data);
 
-            var id = data.id;
+            var id = data.Id;
             Assert.AreEqual("idString", id);
 
-            var fields = data.fields;
+            var fields = data.Fields;
             Assert.IsNotNull(fields);
             Assert.AreEqual(2, fields.Count);
 
             //verify data
-            var firstName = fields[0].name;
+            var firstName = fields[0].Name;
             Assert.AreEqual("intField", firstName);
 
-            var firstValue = fields[0].value;
+            var firstValue = fields[0].Value;
             Assert.IsNotNull(firstValue);
             Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
 
             var intType = firstValue as Int16Type;
             Assert.AreEqual(123, intType.Data);
 
-            var secondName = fields[1].name;
+            var secondName = fields[1].Name;
             Assert.AreEqual("stringField", secondName);
 
-            var secondValue = fields[1].value;
+            var secondValue = fields[1].Value;
             Assert.IsNotNull(secondValue);
             Assert.IsInstanceOfType(secondValue, typeof(StringType));
 

--- a/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
+++ b/Graffle.FlowSdk.Tests/ValueTypes/StructTypeTests.cs
@@ -17,10 +17,10 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             var id = "idString";
             var intType = new Int16Type(123);
             var stringType = new StringType("hello");
-            var fields = new List<(string, FlowValueType)>()
+            var fields = new List<StructField>()
             {
-                ("intField", intType),
-                ("stringField", stringType)
+                new StructField("intField", intType),
+                new StructField("stringField", stringType)
             };
 
             var structType = new StructType(id, fields);
@@ -39,10 +39,10 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             var id = "idString";
             var intType = new Int16Type(123);
             var stringType = new StringType("hello");
-            var fields = new List<(string, FlowValueType)>()
+            var fields = new List<StructField>()
             {
-                ("intField", intType),
-                ("stringField", stringType)
+                new StructField("intField", intType),
+                new StructField("stringField", stringType)
             };
 
             var structType = new StructType(id, fields);
@@ -66,28 +66,28 @@ namespace Graffle.FlowSdk.Tests.ValueTypes
             var data = structType.Data;
             Assert.IsNotNull(data);
 
-            var id = data.id;
+            var id = data.Id;
             Assert.AreEqual("idString", id);
 
-            var fields = data.fields;
+            var fields = data.Fields;
             Assert.IsNotNull(fields);
             Assert.AreEqual(2, fields.Count);
 
             //verify data
-            var firstName = fields[0].name;
+            var firstName = fields[0].Name;
             Assert.AreEqual("intField", firstName);
 
-            var firstValue = fields[0].value;
+            var firstValue = fields[0].Value;
             Assert.IsNotNull(firstValue);
             Assert.IsInstanceOfType(firstValue, typeof(Int16Type));
 
             var intType = firstValue as Int16Type;
             Assert.AreEqual(123, intType.Data);
 
-            var secondName = fields[1].name;
+            var secondName = fields[1].Name;
             Assert.AreEqual("stringField", secondName);
 
-            var secondValue = fields[1].value;
+            var secondValue = fields[1].Value;
             Assert.IsNotNull(secondValue);
             Assert.IsInstanceOfType(secondValue, typeof(StringType));
 

--- a/Graffle.FlowSdk/Graffle.FlowSdk.csproj
+++ b/Graffle.FlowSdk/Graffle.FlowSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.1.9-prerelease</Version>
+    <Version>0.1.10-prerelease</Version>
     <PackageDescription>Sdk for interacting with the Flow blockchain.</PackageDescription>
     <RepositoryUrl>https://github.com/Graffle/flow-c-sharp-sdk</RepositoryUrl>
     <Company>Graffle Labs Inc.</Company>

--- a/Graffle.FlowSdk/Types/StructData.cs
+++ b/Graffle.FlowSdk/Types/StructData.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Graffle.FlowSdk.Types
+{
+    public class StructData
+    {
+        public StructData(string id, List<StructField> fields)
+        {
+            Id = id;
+            Fields = fields;
+        }
+
+        public string Id { get; set; }
+
+        public List<StructField> Fields { get; set; }
+    }
+}

--- a/Graffle.FlowSdk/Types/StructField.cs
+++ b/Graffle.FlowSdk/Types/StructField.cs
@@ -1,0 +1,15 @@
+namespace Graffle.FlowSdk.Types
+{
+    public class StructField
+    {
+        public StructField(string name, FlowValueType value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public string Name { get; set; }
+
+        public FlowValueType Value { get; set; }
+    }
+}


### PR DESCRIPTION
Discovered an issue with the ValueTuples I initially implemented here:

First issue here is how the json was being serialized to cosmos - notice how the field names are not being serialized

```json
{
          "Item1": "A.76b2527585e45db4.SoulMadeComponent.ComponentDetail",
          "Item2": [
              {
                  "Item1": "id",
                  "Item2": {
                      "Type": "UInt64",
                      "Data": 2605
                  }
              },
              {
                  "Item1": "series",
                  "Item2": {
                      "Type": "String",
                      "Data": "Souly1"
                  }
              },
              {
                  "Item1": "name",
                  "Item2": {
                      "Type": "String",
                      "Data": "toapaper"
                  }
              },
              {
                  "Item1": "description",
                  "Item2": {
                      "Type": "String",
                      "Data": "toapaper"
                  }
              },
              {
                  "Item1": "category",
                  "Item2": {
                      "Type": "String",
                      "Data": "Hand-Accessory"
                  }
              },
              {
                  "Item1": "layer",
                  "Item2": {
                      "Type": "UInt64",
                      "Data": 4
                  }
              },
              {
                  "Item1": "color",
                  "Item2": {
                      "Type": "String",
                      "Data": "Happy"
                  }
              },
              {
                  "Item1": "edition",
                  "Item2": {
                      "Type": "UInt64",
                      "Data": 13
                  }
              },
              {
                  "Item1": "maxEdition",
                  "Item2": {
                      "Type": "UInt64",
                      "Data": 25
                  }
              },
              {
                  "Item1": "ipfsHash",
                  "Item2": {
                      "Type": "String",
                      "Data": "toapaper"
                  }
              }
          ]
      }
```

Secondly in the live miner - System.Text.Json has until recently had issues serializing ValueTuples, with the prior implementation the live miner is just sending empty json to the service bus instead of the struct data